### PR TITLE
Add subtract skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,6 +35,14 @@
       "author": {
         "name": "Taivo Marketplace"
       }
+    },
+    {
+      "name": "subtract",
+      "source": "./skills/.curated/subtract",
+      "description": "Critique a plan, design, process, or document through a subtractive lens. USE WHEN user asks to simplify, cut, focus, reduce, tighten, or critique something for bloat \u2014 or when reviewing plans, processes, or designs that feel overbuilt.",
+      "author": {
+        "name": "Taivo Marketplace"
+      }
     }
   ]
 }

--- a/skills/.curated/subtract/.claude-plugin/plugin.json
+++ b/skills/.curated/subtract/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "subtract",
+  "version": "0.1.0",
+  "description": "Critique a plan, design, process, or document through a subtractive lens. USE WHEN user asks to simplify, cut, focus, reduce, tighten, or critique something for bloat \u2014 or when reviewing plans, processes, or designs that feel overbuilt.",
+  "author": {
+    "name": "Taivo Marketplace"
+  }
+}

--- a/skills/.curated/subtract/SKILL.md
+++ b/skills/.curated/subtract/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: subtract
+description: Critique a plan, design, process, or document through a subtractive lens. USE WHEN user asks to simplify, cut, focus, reduce, tighten, or critique something for bloat — or when reviewing plans, processes, or designs that feel overbuilt.
+metadata:
+  distribution:
+    tier: curated
+    publish_anthropic: true
+    plugin_name: subtract
+    plugin_version: 0.1.0
+    plugin_author: Taivo Marketplace
+---
+
+# Subtract
+
+When improving something, people systematically default to adding and overlook removing ([Adams et al., 2021](https://www.nature.com/articles/s41586-021-03380-y)). This skill forces the opposite. Dieter Rams: "Less, but better." Strunk & White: "Omit needless words."
+
+For each component of what you're reviewing:
+
+1. **What is the core?** Say it in one sentence. If you can't, the component isn't clear.
+2. **What breaks if I remove it?** If nothing — cut. If another component absorbs it — merge.
+3. **Is this here for the work, or to signal thoroughness?** Steps that comfort the author but don't change the output are waste.
+
+Then propose the simplified version. Fewer steps that each do real work beat many steps that feel productive.

--- a/skills/.curated/subtract/agents/openai.yaml
+++ b/skills/.curated/subtract/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Subtract"
+  short_description: "Simplify by finding what can be removed"
+  default_prompt: "Use $subtract to simplify this plan by identifying what can be cut or merged."


### PR DESCRIPTION
## Summary

- add the curated `subtract` skill for critiquing plans, designs, processes, and documents through a subtractive lens
- include Codex UI metadata and the generated Anthropic plugin manifest
- register the skill in the generated marketplace catalog

## Why

People often improve work by adding more. This skill makes removal, merging, and focus the default critique strategy.

## Impact

Users can invoke the skill when they want to simplify, cut, tighten, or identify bloat in an artifact or process.

## Validation

- `uv run --with pyyaml python /Users/taivo/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/.curated/subtract`
- `python3 scripts/validate_codex_skills.py`
- `python3 scripts/validate_anthropic_plugins.py`
- `python3 scripts/generate_plugin_manifests.py --check`
- `python3 scripts/generate_marketplace.py --check`
- `git diff --check origin/master...HEAD`

This PR supersedes closed PR #9, whose branch accidentally gained an unrelated commit.